### PR TITLE
Add Postman Collection for API Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,7 @@ Use the read-only role to test if logs are viewable but not downloadable.
 Assignment 1: EC2 provisioning and Spring Boot app deployment with multi-env support
 
 Assignment 2: S3 logging, IAM role separation, and Terraform-based infrastructure extension
+
+## Add Postman Collection for API Testing
+- Added Postman collection to resources/
+- Can be used to test the Spring Boot API deployed via EC2

--- a/resources/DevOps-Assignment.postman_collection.json
+++ b/resources/DevOps-Assignment.postman_collection.json
@@ -1,0 +1,34 @@
+{
+    "info": {
+        "name": "DevOps Assignment - Spring Boot App",
+        "_postman_id": "12345678-abcd-efgh-ijkl-987654321000",
+        "description": "Postman collection to test the /hello endpoint on deployed Spring Boot EC2 app",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+    },
+    "item": [
+        {
+            "name": "GET /hello",
+            "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                    "raw": "http://{{EC2_PUBLIC_IP}}/hello",
+                    "protocol": "http",
+                    "host": [
+                        "{{EC2_PUBLIC_IP}}"
+                    ],
+                    "path": [
+                        "hello"
+                    ]
+                }
+            },
+            "response": []
+        }
+    ],
+    "variable": [
+        {
+            "key": "EC2_PUBLIC_IP",
+            "value": "your-ec2-ip"
+        }
+    ]
+}


### PR DESCRIPTION
- Added Postman collection to resources/
- Can be used to test the Spring Boot API deployed via EC2
